### PR TITLE
Update nmap modules to work with libnmap@0.2.33

### DIFF
--- a/lib/modules/nmap.js
+++ b/lib/modules/nmap.js
@@ -38,10 +38,10 @@ var libnmap = require('libnmap'),
                 defaultValue: '21,22,23,80'
             },
             binPath: {
-                type: 'allValid',
-                description: 'Path of the nmap binary',
-                defaultValue: '/usr/local/bin/nmap'
-            }
+              type: 'allValid',
+              description: 'Path of the nmap binary',
+              defaultValue: 'nmap' // Not need to include full nmap path https://github.com/jas-/node-libnmap/issues/28
+          }
         }
     };
 
@@ -55,13 +55,16 @@ module.exports.run = function (options, callback) {
         range: [options.targets], // array
         ports: options.ports, //string
         nmap: options.binPath
+
     };
 
     // TODO: Not working, "uncaughtException" in the client to the rescue
     try {
         // TODO: Something failing here, only the first ones are scanned
-        libnmap.nmap('scan', opts, function (err, report) {
-            callback(err, report);
+        libnmap.scan(opts, function(err, report) {
+          for (var item in report) {
+            callback(err, report[item]);
+          }
         });
     } catch (err) {
         callback(err);


### PR DESCRIPTION
I'm just make a little change for nmap modules to work with libnmap@0.2.33 . Tested in Arch Linux system.